### PR TITLE
Refine LaTeX resume and apply content corrections

### DIFF
--- a/resume.cls
+++ b/resume.cls
@@ -31,7 +31,7 @@
 \usepackage{fontspec}
 \defaultfontfeatures{Ligatures=TeX}
 \setromanfont[Ligatures=TeX]{EB Garamond}
-\usepackage[activate={true,nocompatibility},final,tracking=true,factor=1100,stretch=10,shrink=10]{microtype}
+\usepackage[final,tracking=true,stretch=10,shrink=10]{microtype}
 
 %----------------------------------------------------------------------------------------
 %	HEADINGS COMMANDS: Commands for printing name and address
@@ -121,8 +121,7 @@
   \\
   {\em #3} \hfill {\em #4} % Italic job title and location
   }\smallskip
-  \begin{list}{$\cdot$}{\leftmargin=0.8em} % \cdot used for bullets, no indentation
-   \itemsep -0.35em \vspace{-0.35em} % Compress items in list together for aesthetics
+  \begin{list}{}{\leftmargin=0.8em \itemsep -0.35em \vspace{-0.35em}} % Start a new list with an indentation but no bullet
   }{
   \end{list}
   \vspace{0.4em} % Some space after the list of bullet points

--- a/resume.tex
+++ b/resume.tex
@@ -18,7 +18,7 @@
 
 \begin{rSection}{Experience}
 
-\begin{rSubsection}{Tesorio}{Apr 2024 - Present}{Head of Devops}{Remote}
+\begin{rSubsection}{Tesorio}{Apr 2024 -- Present}{Head of Devops}{Remote}
 \item[] At Tesorio, the Devops team and I have been working to modernize much of the technology behind the scenes. This has included overhauling how we manage Terraform, Kubernetes, CI, and rebuilding our complex deployment system on top of ArgoCD and Kargo.  We've finished a migration off Heroku, drastically improved our reliability and invested significant effort in performance engineering.
 
 \end{rSubsection}
@@ -33,14 +33,14 @@
 Shortly after joining my boss was let go, and plans for the future changed.
 \end{rSubsection}
 
-\begin{rSubsection}{Release }{October 2021 -- March 2023}{Integration Engineer}{Remote}
+\begin{rSubsection}{Release}{October 2021 -- March 2023}{Integration Engineer}{Remote}
 \item[]Having previously been the first customer of Release, I was intimately involved in shaping the initial feature set.  Eventually, I joined to help found the integration, customer success, and customer onboarding functions.  Being a tiny startup, this involved everything from being involved in sales calls, demos, hiring other members of the team, all the way through to directly contributing features and fixes to the product itself.
 
 The product involved Kubernetes clusters built in customer accounts, and our team was also responsible for all aspects of those clusters, including observability, upgrades, and all other aspects of running dozens of Kubernetes clusters in production.
 \end{rSubsection}
 
 \begin{rSubsection}{Beeswax (Now Comcast)}{August 2020 -- October 2021}{Director of SRE}{Remote}
-\item[]At Beeswax, I inherited the SRE team from the previous manager (the CTO) and overhauled planning, processes, and priorities to improve the teams ability to deliver on slipping commitments.
+\item[]At Beeswax, I inherited the SRE team from the previous manager (the CTO) and overhauled planning, processes, and priorities to improve the team's ability to deliver on slipping commitments.
 
 During my tenure we modernized our loadbalancer layer (with a ~10x perf improvement), migrated to Kubernetes for container orchestration, replaced our observability stack, overhauled CI/CD, upgraded and improved the Aerospike clusters.  We achieved all commitments made to the business on time.
 \end{rSubsection}
@@ -51,9 +51,9 @@ During my tenure we modernized our loadbalancer layer (with a ~10x perf improvem
 
 \begin{rSubsection}{Everquote}{June 2018 -- April 2019}{VP of Infrastructure}{Cambridge, MA}
 \item[] At Everquote, I led the transformation from an outdated "ops team" model to an
-  SRE model.  The two teams I led build self service components for the engineering
+  SRE model.  The two teams I led built self-service components for the engineering
   teams and own the "patterns" used throughout the organization to build, deploy, and
-  operate the 150+ services that compromise the Everquote platform.  I divided my time
+  operate the 150+ services that comprise the Everquote platform.  I divided my time
   between coaching the team, managing infrastructure spend across the
   organization, coordinating across engineering teams, and planning for new
   self service capabilities.
@@ -63,7 +63,7 @@ During my tenure we modernized our loadbalancer layer (with a ~10x perf improvem
 \item[] I led the Infrastructure and Security teams at Cota, working closely with
   software engineering to help build and scale a ``big data" platform for hospitals,
   insurance, and pharmaceutical companies.  These systems helped analyze huge cancer
-  datasets to guide treatments and research.  During my time at Cota I led a overhaul
+  datasets to guide treatments and research.  During my time at Cota I led an overhaul
   in how services were built, deployed, and operated.  This included a cloud migration,
   deployment of Kubernetes, and process changes to software development.
 \end{rSubsection}
@@ -71,10 +71,10 @@ During my tenure we modernized our loadbalancer layer (with a ~10x perf improvem
 \begin{rSubsection}{Maxwell Health}{July 2016 -- December 2017}{Director of Infrastructure}{Boston, MA}
 \item[] At Maxwell Health, I turned around an operations team in crisis.  After
   hiring to bring the team up to full capacity, we built up the infrastructure
-  to turn a six week lead time for servers into an instant self service model
+  to turn a six-week lead time for servers into an instant self-service model
   using Kubernetes.
 
-I split my time between hands on work, such as core infrastructure building,
+I split my time between hands-on work, such as core infrastructure building,
   mentoring team members, working with engineering teams to transform their
   build and deployment pipelines, as well as taking part in SOC2/HIPAA
   compliance work, product strategy planning, and implementing a Production
@@ -84,21 +84,21 @@ I split my time between hands on work, such as core infrastructure building,
 \begin{rSubsection}{nToggle}{January 2015 -- July 2016}{Techops Manager}{Boston, MA}
 
 \item[] At nToggle, I rejoined several of my Jumptap coworkers to help launch
-  an adtech startup that optimizes and reduces Real Time Bidding traffic for
+  an adtech startup that optimizes and reduces Real-Time Bidding traffic for
   our customers.
 
-I designed, and built, our loadbalancer-less (anycast backed) datacenter design
-  to deliver our high performance, low latency, platform.  I also split my time between hands-on engineering work and managing the operations
+I designed and built, our loadbalancer-less (anycast backed) datacenter design
+  to deliver our high-performance, low-latency platform.  I also split my time between hands-on engineering work and managing the operations
   team.  This included hiring budgets, cost models and board presentations
   around CAPEX and OPEX spend, as well as vendor relationships and pre-sales
   engineering work with our customers to accurately model their current
-  infrastructure costs and demonstrate the significant RoI they can achieve
+  infrastructure costs and demonstrate the significant ROI they can achieve
   through nToggle.
 
 \end{rSubsection}
 
 \begin{center}
-Prior "Devops" roles include: Metacloud, Puppetlabs, Jumptap, Edx, SilverSky, Harvard Law School\\
+Prior "DevOps" roles include: Metacloud, Puppetlabs, Jumptap, Edx, SilverSky, Harvard Law School\\
 Prior roles in Europe: School, NTT Europe Online, MessageLabs, Tiscali, Yahoo!, Versatel, Interxion, and Speedport\\
 \textit{Please ask for an expanded resume covering those positions if you're interested in details.}
 \end{center}


### PR DESCRIPTION
This commit introduces several improvements to the LaTeX resume:

For resume.cls:
- Updated microtype package options for modern best practices.
- Modified the rSubsection environment to correctly produce indented paragraphs for job descriptions by default, aligning with the intended visual style.

For resume.tex:
- Ensured consistent use of en-dashes for date ranges.
- Corrected various grammatical points, including possessives, articles, word choice (comprise vs. compromise), and hyphenation of compound adjectives (e.g., self-service, hands-on, six-week, high-performance, low-latency).
- Standardized capitalization for terms like "DevOps" and "Real-Time Bidding".
- Corrected minor formatting issues (e.g., extra space in a company name).
- Maintained job descriptions as single, indented paragraphs as per your preference.